### PR TITLE
disambiguating

### DIFF
--- a/src/gaussian_beam.cpp
+++ b/src/gaussian_beam.cpp
@@ -148,9 +148,7 @@ arma::colvec integrand_gb(const colvec& rt, const colvec& r2, const double ki, \
   }
 
 RCPP_MODULE(gaussian){
-  using namespace Rcpp ;
-  
-  function( "integrand_gb", &integrand_gb,					\
+  Rcpp::function( "integrand_gb", &integrand_gb,					\
 	    "Integrand for the transmitted field under gaussian illumination" ) ;
 
 }

--- a/src/multilayer.cpp
+++ b/src/multilayer.cpp
@@ -227,13 +227,12 @@ Rcpp::List recursive_fresnel(const arma::colvec& k0,			\
 }
 
 RCPP_MODULE(planar){
-  using namespace Rcpp ;
-  function( "layer_fresnel", &layer_fresnel,					\
+  Rcpp::function( "layer_fresnel", &layer_fresnel,					\
 	    "Calculates the reflection and transmission coefficients of a single layer" ) ;
-  function( "multilayer", &multilayer,					\
+  Rcpp::function( "multilayer", &multilayer,					\
 	    "Calculates the reflection and transmission coefficients of a multilayer stack" ) ;
 
-  function( "recursive_fresnel", &recursive_fresnel,					\
+  Rcpp::function( "recursive_fresnel", &recursive_fresnel,					\
 	    "Calculates the reflection coefficient of a multilayer stack" ) ;
 
 }


### PR DESCRIPTION
This should resolve the error. We need to help the compiler disambiguate between `Rcpp::function`and some other symbol called `function`. It is just unfortunate. 

Alternatively you can also use: 

```
using Rcpp::function ;
```

but I'm not sure it works for C++98  
